### PR TITLE
feat(analytics): add flexible runReport tool and refactor existing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,21 +20,57 @@ TypeScript SDK.
 ## Prerequisites
 
 - Node.js 20 or higher
-- Google Analytics 4 property
-- Google Cloud project with Analytics Data API enabled
-- Service account credentials with appropriate permissions
+- A Google Analytics 4 property.
+- A Google Cloud project with the **Analytics Data API** enabled.
+- A service account with credentials to access the API.
 
-## Setup
+## Setup and Configuration
 
-1. Create a Google Cloud project and enable the Analytics Data API
-2. Create a service account and download the credentials JSON file
-3. Grant the service account appropriate access to your GA4 property
-4. Set up environment variables:
+To use this server, you need to configure authentication with Google Analytics. This is done using a service account.
+
+### 1. Enable the Google Analytics Data API
+
+1. Go to the [Google Cloud Console](https://console.cloud.google.com/).
+2. Select the project you want to use.
+3. In the navigation menu, go to **APIs & Services > Library**.
+4. Search for **"Google Analytics Data API"** and enable it.
+
+### 2. Create a Service Account
+
+1. In the Google Cloud Console, navigate to **IAM & Admin > Service Accounts**.
+2. Click **"Create Service Account"**.
+3. Give the service account a name (e.g., "GA4 MCP Server").
+4. Click **"Create and Continue"**.
+5. You can skip granting the service account access to the project.
+6. Click **"Done"**.
+7. Find the service account you just created and click on the three dots under **"Actions"**.
+8. Select **"Manage keys"**, then **"Add Key" > "Create new key"**.
+9. Choose **JSON** as the key type and click **"Create"**. A JSON file with the credentials will be downloaded.
+
+### 3. Grant Service Account Access to Google Analytics
+
+1.  Open [Google Analytics](https://analytics.google.com/).
+2.  Navigate to the **Admin** section of your GA4 property.
+3.  Under the **Property** column, click on **Property Access Management**.
+4.  Click the **"+"** button to add a new user.
+5.  In the **"Email address"** field, paste the `client_email` from the JSON credentials file you downloaded.
+6.  Assign the **"Viewer"** role. You do not need to notify the user.
+7.  Click **"Add"**.
+
+### 4. Set Environment Variables
+
+The server requires the following environment variables:
+
+- `GOOGLE_CLIENT_EMAIL`: The `client_email` from your service account JSON file.
+- `GOOGLE_PRIVATE_KEY`: The `private_key` from your service account JSON file.
+- `GA_PROPERTY_ID`: Your Google Analytics 4 property ID.
+
+You can set them in your environment or use a `.env` file.
 
 ```bash
-export GOOGLE_CLIENT_EMAIL="your-service-account@project.iam.gserviceaccount.com"
-export GOOGLE_PRIVATE_KEY="your-private-key"
-export GA_PROPERTY_ID="your-ga4-property-id"
+export GOOGLE_CLIENT_EMAIL="your-service-account@your-project.iam.gserviceaccount.com"
+export GOOGLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY\n-----END PRIVATE KEY-----\n"
+export GA_PROPERTY_ID="your_property_id"
 ```
 
 ## Installation
@@ -81,6 +117,29 @@ Add this to your Claude Desktop configuration:
 ```
 
 ## Available Functions
+
+### runReport
+
+Run a flexible report to get analytics data.
+
+**Input:**
+
+```json
+{
+  "startDate": "2024-01-01",
+  "endDate": "2024-01-31",
+  "dimensions": [{ "name": "country" }, { "name": "city" }],
+  "metrics": [{ "name": "activeUsers" }, { "name": "newUsers" }],
+  "dimensionFilter": {
+    "filter": {
+      "fieldName": "country",
+      "stringFilter": {
+        "value": "United States"
+      }
+    }
+  }
+}
+```
 
 ### getPageViews
 
@@ -130,11 +189,9 @@ Get user behavior metrics:
 
 ## Security Considerations
 
-- Always use environment variables for sensitive credentials
-- Implement appropriate CORS settings
-- Follow the principle of least privilege when setting up service account permissions
-- Regularly rotate service account credentials
-- Monitor API usage and implement rate limiting if needed
+- **Least Privilege**: Only grant the service account the "Viewer" role in Google Analytics.
+- **Key Management**: Keep your service account key file secure and do not expose it in client-side code.
+- **Environment Variables**: Use environment variables to store sensitive information like the client email, private key, and property ID.
 
 ## Contributing
 


### PR DESCRIPTION
Introduces a new `runReport` tool, allowing for more flexible and customized Google Analytics data queries. This new tool accepts a dynamic schema, enabling users to specify their own dimensions, metrics, and date ranges.

Refactored the existing analytics tools (`getPageViews`, `getActiveUsers`, `getEvents`, `getUserBehavior`) to use a new centralized `fetchAnalyticsData` helper function. This change reduces code duplication and improves maintainability.

The `README.md` has been updated to include documentation for the new `runReport` tool and to clarify the setup instructions.

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a new runReport tool for flexible Google Analytics queries, and refactored existing analytics tools to use a shared fetchAnalyticsData helper.

- **New Features**
  - runReport tool lets users specify custom dimensions, metrics, and date ranges for analytics reports.

- **Refactors**
  - Centralized analytics data fetching to reduce code duplication.
  - Updated README with runReport usage and clearer setup steps.

<!-- End of auto-generated description by cubic. -->

